### PR TITLE
removed hardcoded namespace in gazebo ros controllers

### DIFF
--- a/thormang3_gazebo/config/position_controller.yaml
+++ b/thormang3_gazebo/config/position_controller.yaml
@@ -1,4 +1,4 @@
-thormang3:
+#thormang3:
   # Publish all joint states -----------------------------------
   joint_state_controller:
     type: joint_state_controller/JointStateController

--- a/thormang3_gazebo/launch/position_controller.launch
+++ b/thormang3_gazebo/launch/position_controller.launch
@@ -6,7 +6,7 @@
 
   <!-- load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-	output="screen" ns="/thormang3" args="joint_state_controller
+	output="screen" args="joint_state_controller
 				       		     torso_y_pos
 						     l_arm_sh_p1_pos
 						     l_arm_sh_r_pos

--- a/thormang3_gazebo/launch/robotis_world.launch
+++ b/thormang3_gazebo/launch/robotis_world.launch
@@ -29,7 +29,7 @@
 	args="-urdf -model thormang3 -z 0.9 -param robot_description"/>
 
   <!-- ros_control robotis humanoid launch file -->
-  <group if ="$(arg position_controller)">
+  <group ns="/thormang3" if="$(arg position_controller)">
   	<include file="$(find thormang3_gazebo)/launch/position_controller.launch" />
   </group>
   


### PR DESCRIPTION
Removed hard-coded namespaces for more convenient usage of customized launchfiles.
